### PR TITLE
UpcomingShows filters out events that have already happened

### DIFF
--- a/wild-blue-yonder-website/src/components/UpcomingShows/UpcomingShows.jsx
+++ b/wild-blue-yonder-website/src/components/UpcomingShows/UpcomingShows.jsx
@@ -3,10 +3,23 @@ import ShowItem from "../ShowItem/ShowItem.jsx";
 import shows from "./shows.js";
 
 export default function UpcomingShows() {
+  const currentDate = new Date();
+  const normalizedDate = new Date(
+    currentDate.getFullYear(),
+    currentDate.getMonth(),
+    currentDate.getDate()
+  );
+  console.log(normalizedDate);
+
+  let upcomingShows = shows.filter(
+    (show) => new Date(show.date) >= normalizedDate
+  );
+
+  upcomingShows.sort((a, b) => new Date(a.date) - new Date(b.date));
   return (
     <div className="shows-container">
       <h2 className="upcoming-shows-header">Upcoming Shows</h2>
-      {shows.map((show, index) => {
+      {upcomingShows.map((show, index) => {
         return (
           <ShowItem
             key={index}

--- a/wild-blue-yonder-website/src/components/UpcomingShows/shows.js
+++ b/wild-blue-yonder-website/src/components/UpcomingShows/shows.js
@@ -11,6 +11,11 @@ const shows = [
     name: "Grandview Park",
     location: "Pittsburgh, PA",
   },
+  {
+    date: "June 14, 2025",
+    name: "The Parking Pad",
+    location: "Dormont, PA",
+  },
 ];
 
 export default shows;


### PR DESCRIPTION
UpcomingShows sorts through the list of shows and filters out any shows with a date before the current date. It will also sort the list based on date, so you can insert new shows into shows.js in any order

I left a sample parking pad show inside the js as proof of concept